### PR TITLE
feat: チャットへの画像添付（マルチモーダル対応）

### DIFF
--- a/prisma/migrations/20260318000000_add_image_to_message/migration.sql
+++ b/prisma/migrations/20260318000000_add_image_to_message/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Message" ADD COLUMN "imageData" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,6 +91,7 @@ model Message {
   user          User        @relation(fields: [userId], references: [id], onDelete: Cascade)
   role          String // "user" | "assistant"
   content       String
+  imageData     String?     @db.Text // data URL format: "data:image/jpeg;base64,..."
 
   createdAt DateTime @default(now())
 }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -2,6 +2,7 @@ import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/db/prisma";
 import { anthropic } from "@/lib/ai/client";
 import { SYSTEM_PROMPT, MODEL, MAX_TOKENS, MAX_CONTEXT_TURNS } from "@/lib/ai/persona";
+import Anthropic from "@anthropic-ai/sdk";
 
 export const runtime = "nodejs";
 
@@ -13,6 +14,46 @@ function sseChunk(data: unknown): Uint8Array {
 
 function sseDone(): Uint8Array {
   return encoder.encode("data: [DONE]\n\n");
+}
+
+type SupportedMimeType = "image/jpeg" | "image/png" | "image/gif" | "image/webp";
+const SUPPORTED_MIME_TYPES: readonly SupportedMimeType[] = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+];
+
+function parseDataUrl(dataUrl: string): { mimeType: string; data: string } | null {
+  const match = dataUrl.match(/^data:([^;]+);base64,(.+)$/s);
+  return match ? { mimeType: match[1], data: match[2] } : null;
+}
+
+function buildMessageContent(
+  text: string,
+  imageDataUrl: string | null
+): Anthropic.MessageParam["content"] {
+  if (!imageDataUrl) return text;
+
+  const parsed = parseDataUrl(imageDataUrl);
+  const blocks: Array<Anthropic.ImageBlockParam | Anthropic.TextBlockParam> = [];
+
+  if (parsed && SUPPORTED_MIME_TYPES.includes(parsed.mimeType as SupportedMimeType)) {
+    blocks.push({
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: parsed.mimeType as SupportedMimeType,
+        data: parsed.data,
+      },
+    });
+  }
+
+  if (text.trim()) {
+    blocks.push({ type: "text", text: text.trim() });
+  }
+
+  return blocks.length > 0 ? blocks : text;
 }
 
 export async function POST(req: Request) {
@@ -28,12 +69,15 @@ export async function POST(req: Request) {
   // ── リクエスト解析 ───────────────────────────────────────────────
   let message: string;
   let sessionId: string | null;
+  let imageData: string | null;
   try {
     const body = await req.json();
-    message = body.message;
+    message = typeof body.message === "string" ? body.message : "";
     sessionId = body.sessionId ?? null;
-    if (typeof message !== "string" || !message.trim()) {
-      throw new Error("Invalid message");
+    imageData = typeof body.imageData === "string" ? body.imageData : null;
+
+    if (!message.trim() && !imageData) {
+      throw new Error("Either message or image is required");
     }
   } catch {
     return new Response(JSON.stringify({ error: "Bad Request" }), {
@@ -59,6 +103,7 @@ export async function POST(req: Request) {
     where: { chatSessionId: chatSession.id },
     orderBy: { createdAt: "desc" },
     take: MAX_CONTEXT_TURNS,
+    select: { role: true, content: true, imageData: true },
   });
   history.reverse();
 
@@ -69,6 +114,7 @@ export async function POST(req: Request) {
       userId,
       role: "user",
       content: message.trim(),
+      imageData,
     },
   });
 
@@ -82,12 +128,15 @@ export async function POST(req: Request) {
         );
 
         // Claude API ストリーミング開始
-        const claudeMessages = [
+        const claudeMessages: Anthropic.MessageParam[] = [
           ...history.map((m) => ({
             role: m.role as "user" | "assistant",
-            content: m.content,
+            content: buildMessageContent(m.content, m.imageData ?? null),
           })),
-          { role: "user" as const, content: message.trim() },
+          {
+            role: "user" as const,
+            content: buildMessageContent(message.trim(), imageData),
+          },
         ];
 
         const claudeStream = anthropic.messages.stream({

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -42,7 +42,7 @@ export async function GET(req: Request) {
     const messages = await prisma.message.findMany({
       where: { chatSessionId: chatSession.id },
       orderBy: { createdAt: "asc" },
-      select: { id: true, role: true, content: true },
+      select: { id: true, role: true, content: true, imageData: true },
     });
 
     return new Response(

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -23,7 +23,7 @@ export default async function ChatPage() {
     ? await prisma.message.findMany({
         where: { chatSessionId: chatSession.id },
         orderBy: { createdAt: "asc" },
-        select: { id: true, role: true, content: true },
+        select: { id: true, role: true, content: true, imageData: true },
       })
     : [];
 
@@ -31,6 +31,7 @@ export default async function ChatPage() {
     id: m.id,
     role: m.role as "user" | "assistant",
     content: m.content,
+    imageData: m.imageData,
   }));
 
   return (

--- a/src/components/ChatWindow.tsx
+++ b/src/components/ChatWindow.tsx
@@ -28,6 +28,7 @@ export default function ChatWindow({
   const [input, setInput] = useState("");
   const [isStreaming, setIsStreaming] = useState(false);
   const [sessionId, setSessionId] = useState<string | null>(initialSessionId);
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
 
   const bottomRef = useRef<HTMLDivElement>(null);
 
@@ -38,16 +39,20 @@ export default function ChatWindow({
 
   const handleSend = async () => {
     const text = input.trim();
-    if (!text || isStreaming) return;
+    if ((!text && !selectedImage) || isStreaming) return;
+
+    const imageData = selectedImage;
 
     const userMessage: Message = {
       id: crypto.randomUUID(),
       role: "user",
       content: text,
+      imageData,
     };
 
     setMessages((prev) => [...prev, userMessage]);
     setInput("");
+    setSelectedImage(null);
     setIsStreaming(true);
 
     const assistantId = crypto.randomUUID();
@@ -62,7 +67,7 @@ export default function ChatWindow({
       const res = await fetch("/api/chat", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: text, sessionId }),
+        body: JSON.stringify({ message: text, sessionId, imageData }),
       });
 
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -147,6 +152,9 @@ export default function ChatWindow({
         onChange={setInput}
         onSend={handleSend}
         disabled={isStreaming}
+        selectedImage={selectedImage}
+        onImageSelect={setSelectedImage}
+        onImageClear={() => setSelectedImage(null)}
       />
     </div>
   );

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -1,16 +1,33 @@
 "use client";
 
-import { useRef, useEffect, KeyboardEvent, ChangeEvent } from "react";
+import { useRef, useEffect, KeyboardEvent, ChangeEvent, DragEvent, useState } from "react";
+
+const ACCEPTED_MIME_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
+const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024; // 5MB
 
 type Props = {
   value: string;
   onChange: (value: string) => void;
   onSend: () => void;
   disabled: boolean;
+  selectedImage: string | null;
+  onImageSelect: (dataUrl: string) => void;
+  onImageClear: () => void;
 };
 
-export default function InputBar({ value, onChange, onSend, disabled }: Props) {
+export default function InputBar({
+  value,
+  onChange,
+  onSend,
+  disabled,
+  selectedImage,
+  onImageSelect,
+  onImageClear,
+}: Props) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   // テキストエリアの高さを内容に合わせて自動調整
   useEffect(() => {
@@ -20,10 +37,17 @@ export default function InputBar({ value, onChange, onSend, disabled }: Props) {
     el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
   }, [value]);
 
+  // 画像がクリアされたらファイルインプットもリセット
+  useEffect(() => {
+    if (!selectedImage && fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  }, [selectedImage]);
+
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
-      if (!disabled && value.trim()) {
+      if (!disabled && (value.trim() || selectedImage)) {
         onSend();
       }
     }
@@ -33,33 +57,153 @@ export default function InputBar({ value, onChange, onSend, disabled }: Props) {
     onChange(e.target.value);
   };
 
+  const processFile = (file: File) => {
+    setError(null);
+
+    if (!ACCEPTED_MIME_TYPES.includes(file.type)) {
+      setError("JPEG・PNG・GIF・WebP のみ対応しています");
+      return;
+    }
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      setError("ファイルサイズは 5MB 以下にしてください");
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const result = e.target?.result;
+      if (typeof result === "string") {
+        onImageSelect(result);
+      }
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) processFile(file);
+  };
+
+  const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragging(false);
+  };
+
+  const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragging(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file) processFile(file);
+  };
+
+  const canSend = !disabled && (!!value.trim() || !!selectedImage);
+
   return (
-    <div className="flex items-end gap-2 border-t border-gray-200 bg-white px-4 py-3">
-      <textarea
-        ref={textareaRef}
-        value={value}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        disabled={disabled}
-        placeholder="メッセージを入力…（Shift+Enter で改行）"
-        rows={1}
-        className="flex-1 resize-none rounded-xl border border-gray-300 bg-gray-50 px-3 py-2 text-sm text-gray-800 placeholder-gray-400 outline-none transition focus:border-violet-400 focus:bg-white disabled:opacity-50"
-      />
-      <button
-        onClick={() => !disabled && value.trim() && onSend()}
-        disabled={disabled || !value.trim()}
-        aria-label="送信"
-        className="flex-shrink-0 w-9 h-9 rounded-full bg-violet-500 text-white flex items-center justify-center transition hover:bg-violet-600 disabled:opacity-40 disabled:cursor-not-allowed"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="currentColor"
-          className="w-4 h-4 translate-x-0.5 -translate-y-0.5 rotate-45"
+    <div
+      className={`border-t border-gray-200 bg-white transition ${
+        isDragging ? "bg-violet-50 border-violet-300" : ""
+      }`}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      {/* 画像プレビュー */}
+      {selectedImage && (
+        <div className="px-4 pt-3 flex items-start gap-2">
+          <div className="relative inline-block">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={selectedImage}
+              alt="添付プレビュー"
+              className="h-20 w-auto rounded-lg border border-gray-200 object-contain"
+            />
+            <button
+              onClick={onImageClear}
+              aria-label="画像を削除"
+              className="absolute -top-2 -right-2 w-5 h-5 rounded-full bg-gray-600 text-white flex items-center justify-center hover:bg-gray-800 transition text-xs"
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* エラーメッセージ */}
+      {error && (
+        <p className="px-4 pt-2 text-xs text-red-500">{error}</p>
+      )}
+
+      {/* ドラッグ中のヒント */}
+      {isDragging && (
+        <p className="px-4 pt-2 text-xs text-violet-500 font-medium">
+          ここにドロップして画像を添付
+        </p>
+      )}
+
+      <div className="flex items-end gap-2 px-4 py-3">
+        {/* 画像添付ボタン */}
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          disabled={disabled}
+          aria-label="画像を添付"
+          className="flex-shrink-0 w-9 h-9 rounded-full text-gray-400 flex items-center justify-center transition hover:text-violet-500 hover:bg-violet-50 disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          <path d="M3.478 2.405a.75.75 0 00-.926.94l2.432 7.905H13.5a.75.75 0 010 1.5H4.984l-2.432 7.905a.75.75 0 00.926.94 60.519 60.519 0 0018.445-8.986.75.75 0 000-1.218A60.517 60.517 0 003.478 2.405z" />
-        </svg>
-      </button>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className="w-5 h-5"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5H3.75A1.5 1.5 0 0 0 2.25 6v12a1.5 1.5 0 0 0 1.5 1.5Zm10.5-11.25h.008v.008h-.008V8.25Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"
+            />
+          </svg>
+        </button>
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={ACCEPTED_MIME_TYPES.join(",")}
+          onChange={handleFileChange}
+          className="hidden"
+          aria-hidden="true"
+        />
+
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          disabled={disabled}
+          placeholder="メッセージを入力…（Shift+Enter で改行）"
+          rows={1}
+          className="flex-1 resize-none rounded-xl border border-gray-300 bg-gray-50 px-3 py-2 text-sm text-gray-800 placeholder-gray-400 outline-none transition focus:border-violet-400 focus:bg-white disabled:opacity-50"
+        />
+        <button
+          onClick={() => canSend && onSend()}
+          disabled={!canSend}
+          aria-label="送信"
+          className="flex-shrink-0 w-9 h-9 rounded-full bg-violet-500 text-white flex items-center justify-center transition hover:bg-violet-600 disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            className="w-4 h-4 translate-x-0.5 -translate-y-0.5 rotate-45"
+          >
+            <path d="M3.478 2.405a.75.75 0 00-.926.94l2.432 7.905H13.5a.75.75 0 010 1.5H4.984l-2.432 7.905a.75.75 0 00.926.94 60.519 60.519 0 0018.445-8.986.75.75 0 000-1.218A60.517 60.517 0 003.478 2.405z" />
+          </svg>
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -4,6 +4,7 @@ export type Message = {
   id: string;
   role: "user" | "assistant";
   content: string;
+  imageData?: string | null;
   streaming?: boolean;
 };
 
@@ -24,13 +25,23 @@ export default function MessageBubble({ message }: Props) {
         </div>
       )}
       <div
-        className={`max-w-[70%] rounded-2xl px-4 py-2 text-sm leading-relaxed whitespace-pre-wrap break-words ${
+        className={`max-w-[70%] rounded-2xl px-4 py-2 text-sm leading-relaxed break-words ${
           isUser
             ? "bg-violet-500 text-white rounded-br-sm"
             : "bg-white text-gray-800 rounded-bl-sm shadow-sm border border-gray-100"
         }`}
       >
-        {message.content}
+        {message.imageData && (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={message.imageData}
+            alt="添付画像"
+            className="max-w-full rounded-lg mb-2 max-h-64 object-contain"
+          />
+        )}
+        {message.content && (
+          <span className="whitespace-pre-wrap">{message.content}</span>
+        )}
         {message.streaming && (
           <span className="inline-block w-0.5 h-4 bg-current ml-0.5 align-text-bottom animate-pulse" />
         )}


### PR DESCRIPTION
Closes #2

## 変更内容

- Prisma スキーマに imageData フィールドを追加（data URL 形式、TEXT型）
- DB マイグレーション追加
- /api/chat: 画像データの受け取りと Claude API マルチモーダルメッセージ形式への変換
- InputBar: 画像添付ボタン・プレビュー・D&D・バリデーション

Generated with [Claude Code](https://claude.ai/code)